### PR TITLE
Add linkdeps flag which enables passing flags to link dependent libraries

### DIFF
--- a/examples/make_with_bazel_transitive_final_link/BUILD.bazel
+++ b/examples/make_with_bazel_transitive_final_link/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+
+cc_library(
+    name = "built_with_bazel",
+    srcs = ["builtWithBazel.c"],
+    hdrs = ["builtWithBazel.h"],
+    linkstatic=True,
+    includes = ["."],
+)
+
+make(
+    name = "simple",
+    lib_source = "//make_with_bazel_transitive_final_link/simple_lib:simple_srcs",
+    targets = [
+        "simple",
+    ],
+    out_binaries = [
+        "simple"
+    ],
+    linkdeps=True,
+    deps = [":built_with_bazel"],
+)

--- a/examples/make_with_bazel_transitive_final_link/builtWithBazel.c
+++ b/examples/make_with_bazel_transitive_final_link/builtWithBazel.c
@@ -1,0 +1,5 @@
+#include "builtWithBazel.h"
+
+char* bazelSays(void) {
+  return "It's me, Bazel!";
+}

--- a/examples/make_with_bazel_transitive_final_link/builtWithBazel.h
+++ b/examples/make_with_bazel_transitive_final_link/builtWithBazel.h
@@ -1,0 +1,6 @@
+#ifndef BUILT_WITH_BAZEL_H_
+#define BUILT_WITH_BAZEL_H_ (1)
+
+char* bazelSays(void);
+
+#endif // BUILT_WITH_BAZEL_H_

--- a/examples/make_with_bazel_transitive_final_link/simple_lib/BUILD.bazel
+++ b/examples/make_with_bazel_transitive_final_link/simple_lib/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "simple_srcs",
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/make_with_bazel_transitive_final_link/simple_lib/Makefile
+++ b/examples/make_with_bazel_transitive_final_link/simple_lib/Makefile
@@ -1,0 +1,3 @@
+simple: ./src/simple.c
+	$(CC) $(CPPFLAGS) -o simple.bin ./src/simple.c $(LDFLAGS) -I./include -I.
+	cp simple.bin $(INSTALLDIR)/bin/simple

--- a/examples/make_with_bazel_transitive_final_link/simple_lib/include/simple.h
+++ b/examples/make_with_bazel_transitive_final_link/simple_lib/include/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_ (1)
+
+void simpleFun(void);
+
+#endif // SIMPLE_H_

--- a/examples/make_with_bazel_transitive_final_link/simple_lib/src/simple.c
+++ b/examples/make_with_bazel_transitive_final_link/simple_lib/src/simple.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include "simple.h"
+#include "builtWithBazel.h"
+
+void simpleFun(void) {
+  printf("simpleFun: %s", bazelSays());
+}
+
+int main(int argc, char **argv) {
+    simpleFun();
+}

--- a/foreign_cc/make.bzl
+++ b/foreign_cc/make.bzl
@@ -75,6 +75,7 @@ def _create_make_script(configureParameters):
         inputs = inputs,
         env_vars = user_env,
         make_commands = make_commands,
+        linkdeps = attrs.linkdeps,
     )
 
 def _attrs():

--- a/foreign_cc/private/configure_script.bzl
+++ b/foreign_cc/private/configure_script.bzl
@@ -71,7 +71,7 @@ def create_configure_script(
 
     script.append("##mkdirs## $$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$")
     script.append("{env_vars} {prefix}\"{configure}\" --prefix=$$BUILD_TMPDIR$$/$$INSTALL_PREFIX$$ {user_options}".format(
-        env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs),
+        env_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, False),
         prefix = configure_prefix,
         configure = configure_path,
         user_options = " ".join(user_options),

--- a/foreign_cc/private/framework.bzl
+++ b/foreign_cc/private/framework.bzl
@@ -138,6 +138,11 @@ CC_EXTERNAL_RULE_ATTRIBUTES = {
         mandatory = False,
         default = [],
     ),
+    "linkdeps" : attr.bool (
+        doc = "Whether to pass the flags to link dependent libraries",
+        mandatory = False,
+        default = False,
+    ),
     "out_bin_dir": attr.string(
         doc = "Optional name of the output subdirectory with the binary files, defaults to 'bin'.",
         mandatory = False,

--- a/foreign_cc/private/make_script.bzl
+++ b/foreign_cc/private/make_script.bzl
@@ -11,7 +11,8 @@ def create_make_script(
         env_vars,
         deps,
         inputs,
-        make_commands):
+        make_commands,
+        linkdeps):
     ext_build_dirs = inputs.ext_build_dirs
 
     script = pkgconfig_script(ext_build_dirs)
@@ -19,7 +20,7 @@ def create_make_script(
     script.append("##symlink_contents_to_dir## $$EXT_BUILD_ROOT$$/{} $$BUILD_TMPDIR$$".format(root))
 
     script.append("##enable_tracing##")
-    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs)
+    configure_vars = get_make_env_vars(workspace_name, tools, flags, env_vars, deps, inputs, linkdeps)
     script.extend(["{env_vars} {command}".format(
         env_vars = configure_vars,
         command = command,


### PR DESCRIPTION
This may not work with all compilers but 1. we can disable it and link manually still and 2. it should be easy to fix if compilers need different handling