### PR TITLE
Fix linking against alwayslink=True libraries

### DIFF
--- a/foreign_cc/private/make_env_vars.bzl
+++ b/foreign_cc/private/make_env_vars.bzl
@@ -49,13 +49,7 @@ def _define_deps_flags(deps, inputs, linkdeps):
         # We must de-duplicate the libraries in reverse order to preserve the linking order
         # libs will be reversed after de-duplication to return it to the original order
         for lib in reversed(inputs.libs):
-            libname = lib.basename
-            ext = lib.extension
-            if ext:
-                libname = libname[:-1-len(ext)]
-            if libname.startswith('lib'):
-                libname = libname[3:]
-            libname = "-l" + libname
+            libname = "$$EXT_BUILD_ROOT$$/" + lib.path
             if not lib_set.get(libname):
                 lib_set[libname] = 1
                 libs.append(libname)


### PR DESCRIPTION
Link by passing the entire library path to the linker instead of using -l

Test Plan:
I tested it out locally and it worked for me. @d2b4 please confirm this works for you too and then I'll merge it